### PR TITLE
Left Pane Trigger on Start

### DIFF
--- a/layout/left-panel/action-bar.lua
+++ b/layout/left-panel/action-bar.lua
@@ -11,20 +11,17 @@ local clickable_container = require('widgets.system-elements.clickable-container
 
 return function(s, panel, action_bar_width)
 
-	local menu_icon = wibox.widget {
-		{
-			id = 'menu_btn',
-			image = icons.other.star,
-			resize = true,
-			widget = wibox.widget.imagebox
-		},
-		margins = dpi(10),
-		widget = wibox.container.margin
-	}
-	
 	local home_button = wibox.widget {
 		{
-			menu_icon,
+			{
+        {
+          image = icons.other.shutdown,
+          resize = true,
+          widget = wibox.widget.imagebox
+        },
+        margins = dpi(10),
+        widget = wibox.container.margin
+      },
 			widget = clickable_container
 		},
 		bg = beautiful.background .. '66',
@@ -37,8 +34,8 @@ return function(s, panel, action_bar_width)
 				{},
 				1,
 				nil,
-				function()
-          panel:toggle()
+        function()
+					awesome.emit_signal("module::exit_screen_show")
         end
 			)
 		)
@@ -47,7 +44,6 @@ return function(s, panel, action_bar_width)
 	panel:connect_signal(
 		'opened',
 		function()
-			menu_icon.menu_btn:set_image(gears.surface(icons.ui.close))
 			awesome.emit_signal('widget::toggles:update')
 			awesome.emit_signal('widget::sliders:update')
 		end
@@ -56,7 +52,6 @@ return function(s, panel, action_bar_width)
 	panel:connect_signal(
 		'closed',
 		function()
-			menu_icon.menu_btn:set_image(gears.surface(icons.other.star))
 			awesome.emit_signal('widget::toggles:update')
 			awesome.emit_signal('widget::sliders:update')
 		end

--- a/layout/left-panel/dashboard.lua
+++ b/layout/left-panel/dashboard.lua
@@ -61,62 +61,15 @@ return function(_, panel)
 		)
 	)
 
-	local exit_widget = {
-		{
-			{
-				{
-					image = icons.other.shutdown,
-					resize = true,
-					widget = wibox.widget.imagebox
-				},
-				top = dpi(12),
-				bottom = dpi(12),
-				widget = wibox.container.margin
-			},
-			{
-				text = 'End work session',
-				font = 'SF Pro Text Regular 12',
-				align = 'left',
-				valign = 'center',
-				widget = wibox.widget.textbox
-			},
-			spacing = dpi(24),
-			layout = wibox.layout.fixed.horizontal
-		},
-		left = dpi(24),
-		right = dpi(24),
-		forced_height = dpi(48),
-		widget = wibox.container.margin
+	local exit_hint = {
+    text = 'End work session',
+    font = 'SF Pro Text Regular 12',
+    align = 'right',
+    valign = 'center',
+    widget = wibox.widget.textbox
 	}
 
-	exit_button = wibox.widget {
-		{
-			exit_widget,
-			widget = clickable_container
-
-		},
-		bg = beautiful.groups_bg,
-		shape = function(cr, width, height)
-			gears.shape.rounded_rect(cr, width, height, beautiful.groups_radius) 
-		end,
-		widget = wibox.container.background
-	}
-
-
-	exit_button:buttons(
-		awful.util.table.join(
-			awful.button(
-				{},
-				1,
-				function()
-					panel:toggle()
-					awesome.emit_signal("module::exit_screen_show")
-				end
-			)
-		)
-	)
-
-	return wibox.widget {
+  return wibox.widget {
 		{
 			{
 				layout = wibox.layout.fixed.vertical,
@@ -125,7 +78,7 @@ return function(_, panel)
         require('widgets.favorites')
 			},
 			nil,
-			exit_button,
+			exit_hint,
 			layout = wibox.layout.align.vertical
 		},
 		margins = dpi(16),

--- a/modules/exit-screen.lua
+++ b/modules/exit-screen.lua
@@ -244,7 +244,12 @@ screen.connect_signal(
 
 		awesome.connect_signal(
 			"module::exit_screen_show",
-			function()
+      function()
+        local focused = awful.screen.focused()
+        if focused.left_panel and focused.left_panel.opened then
+          focused.left_panel:toggle()
+        end
+
 				for s in screen do
 					s.exit_screen.visible = false
 				end

--- a/widgets/panel-widgets/start.lua
+++ b/widgets/panel-widgets/start.lua
@@ -42,9 +42,8 @@ local return_button = function()
         1,
         nil,
         function()
-          if mymainmenu then
-            mymainmenu:toggle()
-          end
+          local focused = awful.screen.focused()
+          focused.left_panel:toggle()
         end
       ),
       awful.button(
@@ -62,9 +61,6 @@ local return_button = function()
                     focused.right_panel:HideDashboard()
                 end
           awful.spawn(apps.default.rofiappmenu, false)
-          if mymainmenu then
-            mymainmenu:hide()
-          end
         end
       )
     )


### PR DESCRIPTION
It felt unintuitive to have an icon on the bottom for the left pane after favorite apps have been added and awesome menu is not that useful anymore. Swapped left pane back to start button and replaced the favorites icon with button triggering exit screen

closes #36﻿
