### PR TITLE
Configurable System Tray

### DIFF
--- a/configuration/keys/global.lua
+++ b/configuration/keys/global.lua
@@ -14,13 +14,13 @@ local keyboard_layout = require('widgets.panel-widgets.keyboard-layout.kbdcfg')
 -- Key bindings
 local globalKeys = awful.util.table.join(
 
---  ▄▄▄▄                  ▄                 
--- █▀   ▀ ▄   ▄   ▄▄▄   ▄▄█▄▄   ▄▄▄   ▄▄▄▄▄ 
--- ▀█▄▄▄  ▀▄ ▄▀  █   ▀    █    █▀  █  █ █ █ 
---     ▀█  █▄█    ▀▀▀▄    █    █▀▀▀▀  █ █ █ 
--- ▀▄▄▄█▀  ▀█    ▀▄▄▄▀    ▀▄▄  ▀█▄▄▀  █ █ █ 
---         ▄▀                               
---        ▀▀                                
+--  ▄▄▄▄                  ▄
+-- █▀   ▀ ▄   ▄   ▄▄▄   ▄▄█▄▄   ▄▄▄   ▄▄▄▄▄
+-- ▀█▄▄▄  ▀▄ ▄▀  █   ▀    █    █▀  █  █ █ █
+--     ▀█  █▄█    ▀▀▀▄    █    █▀▀▀▀  █ █ █
+-- ▀▄▄▄█▀  ▀█    ▀▄▄▄▀    ▀▄▄  ▀█▄▄▀  █ █ █
+--         ▄▀
+--        ▀▀
 
 -- ░█░█░█▀▀░█░█░█▀▄░█▀█░█▀█░█▀▄░█▀▄
 -- ░█▀▄░█▀▀░░█░░█▀▄░█░█░█▀█░█▀▄░█░█
@@ -241,13 +241,13 @@ awful.key(
   { description = 'lock the screen', group = 'Utility' }
 ),
 
--- ▄                                    ▄   
--- █       ▄▄▄   ▄   ▄   ▄▄▄   ▄   ▄  ▄▄█▄▄ 
--- █      ▀   █  ▀▄ ▄▀  █▀ ▀█  █   █    █   
--- █      ▄▀▀▀█   █▄█   █   █  █   █    █   
--- █▄▄▄▄▄ ▀▄▄▀█   ▀█    ▀█▄█▀  ▀▄▄▀█    ▀▄▄ 
---                ▄▀                        
---               ▀▀                  
+-- ▄                                    ▄
+-- █       ▄▄▄   ▄   ▄   ▄▄▄   ▄   ▄  ▄▄█▄▄
+-- █      ▀   █  ▀▄ ▄▀  █▀ ▀█  █   █    █
+-- █      ▄▀▀▀█   █▄█   █   █  █   █    █
+-- █▄▄▄▄▄ ▀▄▄▀█   ▀█    ▀█▄█▀  ▀▄▄▀█    ▀▄▄
+--                ▄▀
+--               ▀▀
 awful.key(
   { modkey, altkey}, 'Left',
   function()
@@ -382,11 +382,11 @@ awful.key(
   { description = 'restore minimized', group = 'screen' }
 ),
 
--- ▄    ▄ ▄▄▄▄▄ 
--- █    █   █   
--- █    █   █   
--- █    █   █   
--- ▀▄▄▄▄▀ ▄▄█▄▄ 
+-- ▄    ▄ ▄▄▄▄▄
+-- █    █   █
+-- █    █   █
+-- █    █   █
+-- ▀▄▄▄▄▀ ▄▄█▄▄
 awful.key(
   { 'Control' }, 'Escape',
   function ()
@@ -468,13 +468,13 @@ awful.key(
   { description = 'open notification center', group = 'launcher' }
 ),
 
---   ▄▄                       
---   ██   ▄▄▄▄   ▄▄▄▄    ▄▄▄  
---  █  █  █▀ ▀█  █▀ ▀█  █   ▀ 
---  █▄▄█  █   █  █   █   ▀▀▀▄ 
--- █    █ ██▄█▀  ██▄█▀  ▀▄▄▄▀ 
---        █      █            
---        ▀      ▀            
+--   ▄▄
+--   ██   ▄▄▄▄   ▄▄▄▄    ▄▄▄
+--  █  █  █▀ ▀█  █▀ ▀█  █   ▀
+--  █▄▄█  █   █  █   █   ▀▀▀▄
+-- █    █ ██▄█▀  ██▄█▀  ▀▄▄▄▀
+--        █      █
+--        ▀      ▀
 
 -- ░▀█▀░█▀▀░█▀▄░█▄█░▀█▀░█▀█░█▀█░█░░
 -- ░░█░░█▀▀░█▀▄░█░█░░█░░█░█░█▀█░█░░
@@ -559,24 +559,17 @@ awful.key(
   end,
   { description = 'open default IDE', group = 'launcher' }
 ),
-awful.key(
-  { modkey }, 'm',
-  function()
-    awful.spawn(apps.default.music_player)
-  end,
-  { description = 'open default music player', group = 'launcher' }
-),
-awful.key(
-  { modkey }, 'v',
-  function()
-    awful.spawn(apps.default.video_player)
-  end,
-  { description = 'open default video player', group = 'launcher' }
-),
 
 -- ░█▀▀░█▀▀░█▀▀░█▀█░█▀█░█▀▄░█▀█░█▀▄░█░█
 -- ░▀▀█░█▀▀░█░░░█░█░█░█░█░█░█▀█░█▀▄░░█░
 -- ░▀▀▀░▀▀▀░▀▀▀░▀▀▀░▀░▀░▀▀░░▀░▀░▀░▀░░▀░
+awful.key(
+  { modkey, 'Shift' }, 'm',
+  function()
+    awful.spawn(apps.default.music_player)
+  end,
+  { description = 'open default Music player', group = 'launcher' }
+),
 awful.key(
 	{ modkey, 'Shift' }, 'v',
 	function()

--- a/configuration/preferences.lua
+++ b/configuration/preferences.lua
@@ -3,16 +3,20 @@ local dpi = beautiful.xresources.apply_dpi
 
 return {
   system = {
-    icons_update_interval = 5,      -- in seconds
+    icons_update_interval = 5,  -- in seconds
   },
   system_tray = {
-    expanded = true,                -- true or false
-    orientation = 'vertical'        -- 'vertical' or 'horizontal'
+    expanded = true,            -- true or false
+    orientation = 'vertical'    -- 'vertical' or 'horizontal', will move the widget between the top and side bars
   },
   formatting = {
     time_short = '%l:%M %p',
-    time_long = '',
+    time_long = '%l:%M:%S %p',
     date_short = '%a, %d %b',
     date_long = '%a, %d %b %Y',
   },
+  panels = {
+    size_top = dpi(40),
+    size_side = dpi(45),
+  }
 }

--- a/configuration/preferences.lua
+++ b/configuration/preferences.lua
@@ -1,9 +1,18 @@
+local beautiful = require('beautiful')
+local dpi = beautiful.xresources.apply_dpi
+
 return {
   system = {
+    icons_update_interval = 5,      -- in seconds
+  },
+  system_tray = {
+    expanded = true,                -- true or false
+    orientation = 'vertical'        -- 'vertical' or 'horizontal'
+  },
+  formatting = {
     time_short = '%l:%M %p',
     time_long = '',
     date_short = '%a, %d %b',
     date_long = '%a, %d %b %Y',
-    icons_update_interval = 5,
-  }
+  },
 }

--- a/layout/left-panel/action-bar.lua
+++ b/layout/left-panel/action-bar.lua
@@ -1,13 +1,14 @@
 local awful = require('awful')
-local beautiful = require('beautiful')
-local wibox = require('wibox')
 local gears = require('gears')
-
+local wibox = require('wibox')
+local beautiful = require('beautiful')
 local dpi = beautiful.xresources.apply_dpi
+
+local clickable_container = require('library.ui.clickable-container.with-background')
+local user_preferences = require('configuration.preferences')
 local icons = require('theme.icons')
 
 local tag_list = require('widgets.panel-widgets.tag-list')
-local clickable_container = require('library.ui.clickable-container.with-background')
 
 return function(s, panel, action_bar_width)
 
@@ -73,7 +74,7 @@ return function(s, panel, action_bar_width)
 		},
 		nil,
 		{
-			require('widgets.panel-widgets.system-tray')(s, action_bar_width),
+      require('widgets.panel-widgets.system-tray')(s, action_bar_width, 'vertical'),
 			home_button,
 			layout = wibox.layout.fixed.vertical,
 		}

--- a/layout/left-panel/action-bar.lua
+++ b/layout/left-panel/action-bar.lua
@@ -74,7 +74,7 @@ return function(s, panel, action_bar_width)
 		},
 		nil,
 		{
-      require('widgets.panel-widgets.system-tray')(s, action_bar_width, 'vertical'),
+      require('widgets.panel-widgets.system-tray')(s, 'vertical'),
 			home_button,
 			layout = wibox.layout.fixed.vertical,
 		}

--- a/layout/left-panel/init.lua
+++ b/layout/left-panel/init.lua
@@ -1,12 +1,14 @@
 local awful = require('awful')
-local beautiful = require('beautiful')
 local wibox = require('wibox')
+local beautiful = require('beautiful')
+local dpi = beautiful.xresources.apply_dpi
+
 local apps = require('configuration.apps')
-local dpi = require('beautiful').xresources.apply_dpi
+local user_preferences = require('configuration.preferences')
 
 local left_panel = function(screen)
-	
-	local action_bar_width = dpi(45)
+
+	local action_bar_width = user_preferences.panels.size_side
 	local panel_content_width = dpi(350)
 
 	local panel =
@@ -52,7 +54,7 @@ local left_panel = function(screen)
 				panel:toggle()
 			end
 		)
-		
+
 		-- Hide panel content if rofi global search is opened
 		panel:get_children_by_id('panel_content')[1].visible = false
 	end

--- a/layout/notification_tray.lua
+++ b/layout/notification_tray.lua
@@ -32,14 +32,14 @@ local build = function(s)
 
   local date = wibox.widget {
     format = '<span font="SF Pro Text Bold 11">'
-    .. user_preferences.system.date_long
+    .. user_preferences.formatting.date_long
     ..'</span>',
     widget = wibox.widget.textclock
   }
 
   local time = wibox.widget {
     format = '<span font="SF Pro Text Bold 11">'
-    .. user_preferences.system.time_short
+    .. user_preferences.formatting.time_short
     ..'</span>',
     widget = wibox.widget.textclock
   }

--- a/layout/top-panel.lua
+++ b/layout/top-panel.lua
@@ -10,13 +10,19 @@ local icons = require('theme.icons')
 
 local task_list = require('widgets.panel-widgets.task-list')
 
-local panelSize = dpi(40)
+local panelSize = user_preferences.panels.size_top
 
 local TopPanel = function(s, offset)
 
+  if s.index == 1 then
+    s.sys_tray = require('widgets.panel-widgets.system-tray')(s, 'horizontal')
+  else
+    s.sys_tray = nil
+  end
+
 	local offsetx = 0
 	if offset == true then
-		offsetx = dpi(45)
+		offsetx = user_preferences.panels.size_side
 	end
 
 	local panel = wibox
@@ -33,12 +39,10 @@ local TopPanel = function(s, offset)
 		fg = beautiful.fg_normal
 	}
 
-
 	panel:struts
 	{
 		top = panelSize
 	}
-
 
 	panel:connect_signal(
 		'mouse::enter',
@@ -50,7 +54,6 @@ local TopPanel = function(s, offset)
 		end
 
 	)
-
 
 	s.add_button = wibox.widget {
 		{
@@ -213,7 +216,7 @@ local TopPanel = function(s, offset)
 	local tray_widgets = wibox.widget {
 		{
       s.status_icons,
-      -- require('widgets.panel-widgets.system-tray')(s, panelSize, 'horizontal'),
+      s.sys_tray,
 			require('widgets.panel-widgets.keyboard-layout'),
 			-- require('widgets.panel-widgets.music')(),
 			require('widgets.panel-widgets.package-updater')(),

--- a/layout/top-panel.lua
+++ b/layout/top-panel.lua
@@ -4,10 +4,10 @@ local wibox = require('wibox')
 local beautiful = require('beautiful')
 local dpi = beautiful.xresources.apply_dpi
 
+local clickable_container = require('library.ui.clickable-container.with-background')
 local user_preferences = require('configuration.preferences')
 local icons = require('theme.icons')
 
-local clickable_container = require('library.ui.clickable-container.with-background')
 local task_list = require('widgets.panel-widgets.task-list')
 
 local panelSize = dpi(40)
@@ -95,7 +95,7 @@ local TopPanel = function(s, offset)
 
 	s.clock_widget = wibox.widget.textclock(
     '<span font="SF Pro Text Bold 11">'
-    .. user_preferences.system.time_short
+    .. user_preferences.formatting.time_short
     ..'</span>',
 		1
 	)
@@ -213,7 +213,7 @@ local TopPanel = function(s, offset)
 	local tray_widgets = wibox.widget {
 		{
       s.status_icons,
-			-- require('widgets.panel-widgets.system-tray')(s, panelSize),
+      -- require('widgets.panel-widgets.system-tray')(s, panelSize, 'horizontal'),
 			require('widgets.panel-widgets.keyboard-layout'),
 			-- require('widgets.panel-widgets.music')(),
 			require('widgets.panel-widgets.package-updater')(),

--- a/library/ui/launcher-line.lua
+++ b/library/ui/launcher-line.lua
@@ -1,8 +1,6 @@
-local awful = require('awful')
 local gears = require('gears')
 local wibox = require('wibox')
 local beautiful = require('beautiful')
-
 local dpi = require('beautiful').xresources.apply_dpi
 
 local build = function(size)
@@ -14,7 +12,7 @@ local build = function(size)
       shape = gears.shape.rounded_bar,
       widget = wibox.container.background
     },
-    margins = dpi(5),
+    top = dpi(2),
     widget = wibox.container.margin
   }
 
@@ -28,7 +26,7 @@ local build = function(size)
 			end
 		end
   )
-  
+
   widget:connect_signal(
 		'mouse::leave',
 		function()

--- a/widgets/panel-widgets/system-tray/init.lua
+++ b/widgets/panel-widgets/system-tray/init.lua
@@ -1,27 +1,38 @@
+-- TODO
+-- Calling widget from the top bar overwrites the size in the side bar
+-- Might be better to move the bar sizes to the preferences file
+
 local wibox = require('wibox')
 local beautiful = require('beautiful')
-
 local dpi = beautiful.xresources.apply_dpi
 
-local vertical_orientation = true
-local expanded_by_default = true
+local user_preferences = require('configuration.preferences')
+
 local widgets_dpi = dpi(4)
 local rotation
 
-return function(s, action_bar_size)
+local build = function(s, size, orientation)
+  local vertical_orientation
 
-  if vertical_orientation then
+  if user_preferences.system_tray.orientation == 'vertical' then
     rotation = 'east'
+    vertical_orientation = true
     s.separator = require('library.ui.separator')('h')
-  else
+  elseif user_preferences.system_tray.orientation == 'horizontal' then
     rotation = 'north'
+    vertical_orientation = false
+    s.separator = require('library.ui.separator')('v')
+  else
+    require('naughty').notify { text = 'System Tray widget called with wrong orientation' }
+    rotation = 'north'
+    vertical_orientation = false
     s.separator = require('library.ui.separator')('v')
   end
 
   s.systray = wibox.widget {
     {
       {
-        base_size = action_bar_size - 2*widgets_dpi,
+        base_size = size - 2*widgets_dpi,
         horizontal = not vertical_orientation,
         screen = 'primary',
         widget = wibox.widget.systray
@@ -40,31 +51,36 @@ return function(s, action_bar_size)
     widget = wibox.container.rotate
   }
 
-  if expanded_by_default then
+  if user_preferences.system_tray.expanded then
     awesome.emit_signal("widget::systray:toggle")
   end
-  
-  if vertical_orientation then
-    return wibox.widget {
-      id = 'system_tray',
-      layout = wibox.layout.fixed.vertical,
-      forced_width = action_bar_size - 2*widgets_dpi,
-      s.tray_toggler,
-      s.separator,
-      s.systray,
-      s.separator
-    }
+
+  if user_preferences.system_tray.orientation == orientation then
+    if vertical_orientation then
+      return wibox.widget {
+        id = 'system_tray',
+        layout = wibox.layout.fixed.vertical,
+        forced_width = size - 2*widgets_dpi,
+        s.tray_toggler,
+        s.separator,
+        s.systray,
+        s.separator
+      }
+    else
+      return wibox.widget {
+        id = 'system_tray',
+        layout = wibox.layout.fixed.horizontal,
+        forced_height = size,
+        s.tray_toggler,
+        s.separator,
+        s.systray,
+        s.separator,
+      }
+    end
   else
-    return wibox.widget {
-      id = 'system_tray',
-      layout = wibox.layout.fixed.horizontal,
-      forced_height = action_bar_size,
-      s.tray_toggler,
-      s.separator,
-      s.systray,
-      s.separator,
-    }
+    return nil
   end
 
-  
 end
+
+return build

--- a/widgets/panel-widgets/system-tray/init.lua
+++ b/widgets/panel-widgets/system-tray/init.lua
@@ -1,7 +1,3 @@
--- TODO
--- Calling widget from the top bar overwrites the size in the side bar
--- Might be better to move the bar sizes to the preferences file
-
 local wibox = require('wibox')
 local beautiful = require('beautiful')
 local dpi = beautiful.xresources.apply_dpi
@@ -9,23 +5,26 @@ local dpi = beautiful.xresources.apply_dpi
 local user_preferences = require('configuration.preferences')
 
 local widgets_dpi = dpi(4)
-local rotation
+local rotation, size
 
-local build = function(s, size, orientation)
+local build = function(s, orientation)
   local vertical_orientation
 
   if user_preferences.system_tray.orientation == 'vertical' then
     rotation = 'east'
     vertical_orientation = true
+    size = user_preferences.panels.size_side
     s.separator = require('library.ui.separator')('h')
   elseif user_preferences.system_tray.orientation == 'horizontal' then
     rotation = 'north'
     vertical_orientation = false
+    size = user_preferences.panels.size_top
     s.separator = require('library.ui.separator')('v')
   else
     require('naughty').notify { text = 'System Tray widget called with wrong orientation' }
     rotation = 'north'
     vertical_orientation = false
+    size = user_preferences.panels.size_top
     s.separator = require('library.ui.separator')('v')
   end
 


### PR DESCRIPTION
- tied widget to the user preferences config
- panel sizes and system tray are now set in the preferences config
- Changing sys_tray orientation in the preferences config will move the widget between the top and size panels

closes #9
