### PR TITLE
client gaps

### DIFF
--- a/configuration/apps.lua
+++ b/configuration/apps.lua
@@ -1,6 +1,6 @@
 local filesystem = require('gears.filesystem')
 local config_dir = filesystem.get_configuration_dir()
-local sounds = require('theme.sounds')
+local sounds     = require('theme.sounds')
 
 -- The default applications that we will use in keybindings and widgets
 local default = {

--- a/configuration/client/keys.lua
+++ b/configuration/client/keys.lua
@@ -1,5 +1,4 @@
 local awful = require('awful')
-local gears = require('gears')
 local beautiful = require('beautiful')
 local dpi = beautiful.xresources.apply_dpi
 
@@ -8,7 +7,7 @@ require('awful.autofocus')
 local modkey = require('configuration.keys.mod').modKey
 local altkey = require('configuration.keys.mod').altKey
 
--- increment for moving and resizing floting windows
+-- increment for moving and resizing floating windows
 local step = dpi(50)
 
 local clientKeys = awful.util.table.join(
@@ -87,7 +86,7 @@ awful.key(
 
 -- toggle client floating mode
 awful.key(
-	{modkey}, 'f',
+	{modkey}, 'w',
 	function(c)
 		c.fullscreen = false
     c.maximized = false
@@ -111,9 +110,9 @@ awful.key(
 	end,
 	{description = 'toggle max', group = 'client'}
 ),
--- toggle client fullscreen mode
+-- toggle client full screen mode
 awful.key(
-	{modkey}, 'F11',
+	{modkey}, 'f',
 	function(c)
     c.floating = false
     c.maximized = false
@@ -122,7 +121,7 @@ awful.key(
 		c.fullscreen = not c.fullscreen
 		c:raise()
 	end,
-	{description = 'toggle fullscreen', group = 'client'}
+	{description = 'toggle full screen', group = 'client'}
 ),
 -- toggle client sticky mode
 awful.key(

--- a/configuration/client/rules.lua
+++ b/configuration/client/rules.lua
@@ -18,26 +18,26 @@ ruled.client.connect_signal(
     -- All clients will match this rule.
 
 		ruled.client.append_rule {
-			id         = "global",
-			rule       = { },
-			properties = {
-        focus     = awful.client.focus.filter,
-        switchtotag = true,
-				raise     = true,
-				floating = false,
-				maximized = false,
-				above = false,
-				below = false,
-				ontop = false,
-				sticky = false,
+			id                     = "global",
+			rule                   = { },
+			properties             = {
+        focus                = awful.client.focus.filter,
+        switchtotag          = true,
+				raise                = true,
+				floating             = false,
+				maximized            = false,
+				above                = false,
+				below                = false,
+				ontop                = false,
+				sticky               = false,
 				maximized_horizontal = false,
-				maximized_vertical = false,
-				round_corners = false,
-				keys = client_keys,
-				buttons = client_buttons,
-				screen    = 'primary', -- new clients default to primary screen
-				-- screen    = awful.screen.preferred, -- new clients default to focused screen
-				placement = awful.placement.no_overlap + awful.placement.no_offscreen + awful.placement.centered
+				maximized_vertical   = false,
+				round_corners        = false,
+				keys                 = client_keys,
+				buttons              = client_buttons,
+				screen               = 'primary', -- new clients default to primary screen
+				-- screen            = awful.screen.preferred, -- new clients default to focused screen
+				placement            = awful.placement.no_overlap + awful.placement.no_offscreen + awful.placement.centered
 			}
 		}
 
@@ -61,8 +61,9 @@ ruled.client.connect_signal(
 				instance = { "QuakeTerminal" }
 			},
 			properties = {
-        tag = 'terminal',
-        screen = awful.tag.find_by_name(nil, 'terminal').screen,
+        tag = 'coding',
+        hide_titlebars = true,
+        -- screen = awful.tag.find_by_name(nil, 'terminal').screen,
 				size_hints_honor = false
 			}
 		}

--- a/configuration/client/rules.lua
+++ b/configuration/client/rules.lua
@@ -172,34 +172,21 @@ ruled.client.connect_signal(
 			}
 		}
 
-		-- ruled.client.append_rule {
-		-- 	id         = "steam_dialogs",
-		-- 	rule_any   = {
-		-- 		name = {
-		-- 			"- Steam",
-    --       -- "Settings",
-    --       -- "Properties",
-    --       -- "News",
-    --       -- "Login",
-    --       "Steam Guard"
-		-- 		}
-		-- 	},
-		-- 	properties = {
-    --     tag = 'gaming',
-    --     screen = 1,
-    --     maximized = false,
-    --     floating = true,
-    --     hide_titlebars = false,
-		-- 	}
-		-- }
-
 		ruled.client.append_rule {
 			id         = "games",
 			rule_any   = {
 				class = {
 					"steam_app",
+        },
+        name = {
+					"Witcher",
 				}
-			},
+      },
+      except_any = {
+        name = {
+					"Steam",
+				}
+      },
 			properties = {
         tag = 'gaming',
         screen = 1,

--- a/configuration/client/rules.lua
+++ b/configuration/client/rules.lua
@@ -63,7 +63,6 @@ ruled.client.connect_signal(
 			properties = {
         tag = 'coding',
         hide_titlebars = true,
-        -- screen = awful.tag.find_by_name(nil, 'terminal').screen,
 				size_hints_honor = false
 			}
 		}
@@ -75,11 +74,13 @@ ruled.client.connect_signal(
           "whatsapp",
           "Slack",
           "obs",
+          "Spotify",
+          "youtubemusic"
           }
 			},
 			properties = {
-        tag = 'terminal',
-        screen = awful.tag.find_by_name(nil, 'terminal').screen,
+        tag = 'misc',
+        screen = awful.tag.find_by_name(nil, 'misc').screen,
 			}
 		}
 
@@ -262,11 +263,8 @@ ruled.client.connect_signal(
 			rule_any   = {
         class = {
           "vlc",
-          "Spotify",
           "Celluloid",
-          "youtubemusic"
-        },
-        name = { "Google Play Music" }
+        }
       },
 			properties = {
         tag = 'multimedia',

--- a/configuration/keys/global.lua
+++ b/configuration/keys/global.lua
@@ -1,5 +1,4 @@
 local awful = require('awful')
-local beautiful = require('beautiful')
 local system = require('modules.system-control')
 
 require('awful.autofocus')

--- a/configuration/tags.lua
+++ b/configuration/tags.lua
@@ -6,9 +6,9 @@ local monitor = require('modules.monitor')
 
 local tags = {
 	{
-		name = 'terminal',
+		name = 'misc',
 		icon = icons.tags.terminal,
-		default_app = apps.default.terminal,
+		default_app = apps.default.music_player,
     layout = awful.layout.suit.tile,
 		screen = 2,
     selected = true,

--- a/configuration/tags.lua
+++ b/configuration/tags.lua
@@ -29,7 +29,6 @@ local tags = {
 		name = 'coding',
 		icon = icons.tags.text_editor,
 		default_app = apps.default.ide,
-    layout = awful.layout.suit.max,
 	},
 	{
 		name = 'computer',
@@ -72,7 +71,7 @@ for i, tag in pairs(tags) do
       layout              = tag.layout or awful.layout.suit.tile,
       default_layout      = tag.layout or awful.layout.suit.tile,
       gap                 = tag.gap or beautiful.useless_gap,
-      gap_single_client   = tag.single_client_gap or false,
+      gap_single_client   = tag.single_client_gap or true,
       master_count        = monitor.orientation(tag.screen) == 'portrait' and 0 or nil,
       selected            = tag.selected or tag.screen ~= nil and tag.screen <= screen:instances() or false,
       screen              = tag.screen or tag.screen ~= nil and tag.screen <= screen:instances() or 'primary',

--- a/modules/decorate-client.lua
+++ b/modules/decorate-client.lua
@@ -25,9 +25,10 @@ local function render_client(client, mode)
     end
   elseif client.rendering_mode ~= 'maximized' then
     client.border_width = beautiful.border_width
-    client.shape = function(cr, w, h)
-      gears.shape.rounded_rect(cr, w, h, beautiful.client_radius)
-    end
+    -- disable rounded corners on newly spawned clients
+    -- client.shape = function(cr, w, h)
+      -- gears.shape.rounded_rect(cr, w, h, beautiful.client_radius)
+    -- end
   end
 
 end

--- a/modules/menu.lua
+++ b/modules/menu.lua
@@ -162,6 +162,11 @@ else
 
     items = {
       {
+        "Terminal",
+        apps.default.terminal,
+        menubar.utils.lookup_icon("utilities-terminal")
+      },
+      {
         "Instructions",
         function()
           local naughty = require('naughty')


### PR DESCRIPTION
- changed mapping for fullscreen and floating
- enabled single gap
- disabled hardcoded rounded corners for new client spawns
- Repurposing secondary screen for misc.
